### PR TITLE
fix: Sync env vars and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,18 @@
 ﻿# Azure OpenAI Configuration
-AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here
-AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_API_VERSION=2024-02-15-preview
 AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o
 AZURE_OPENAI_MODEL_NAME=gpt-4o
 
-# Database Configuration
-AZURE_DATABASE_ENDPOINT=sqlite:///./temp.db    
-AZURE_DATABASE_ID=your_database_id_here
-AZURE_DATABASE_PASSWORD=your_database_password_here
+# Database Configuration (PostgreSQL)
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_SERVER=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=app_db
 
-DB_PORT=5432
-
+# Azure Blob Storage Configuration
+AZURE_STORAGE_ACCOUNT_NAME=
+AZURE_STORAGE_ACCOUNT_KEY=
+AZURE_STORAGE_CONTAINER_NAME=images


### PR DESCRIPTION
Closes #15. Updates .env.example to use AZURE_STORAGE_ACCOUNT_NAME and KEY instead of CONNECTION_STRING, matching the codebase changes.