### PR TITLE
recommendation_prompts.py 수정

### DIFF
--- a/app/ai/prompts/extraction_prompts.py
+++ b/app/ai/prompts/extraction_prompts.py
@@ -1,53 +1,341 @@
 """
 이미지 속성 추출 프롬프트 템플릿
 """
+
 from typing import Dict, List
 
-# Enums
+# ENUMS
 ENUMS = {
-    "category_main": ["outer", "top", "bottom", "onepiece", "shoes", "bag", "accessory"],
+    "category_main": ["outer", "top", "bottom", "onepiece", "shoes", "accessory"],
     "category_sub": [
-        "coat", "puffer", "jacket", "blazer", "cardigan", "hoodie", "sweatshirt",
-        "shirt", "tshirt", "knit", "sweater", "slacks", "jeans", "shorts",
-        "skirt", "dress", "sneakers", "loafers", "heels", "boots",
-        "bag", "cap", "hat", "scarf", "belt", "other", "unknown"
+        "coat",
+        "puffer",
+        "jacket",
+        "blazer",
+        "cardigan",
+        "hoodie",
+        "sweatshirt",
+        "blouses",
+        "shirt",
+        "tshirt",
+        "knit",
+        "sweater",
+        "slacks",
+        "jeans",
+        "shorts",
+        "skirt",
+        "dress",
+        "sneakers",
+        "loafers",
+        "heels",
+        "boots",
+        "camisoles",
+        "bag",
+        "cap",
+        "hat",
+        "scarf",
+        "belt",
+        "other",
+        "unknown",
     ],
     "color": [
-        "black", "white", "gray", "navy", "blue", "skyblue", "beige", "brown", "khaki",
-        "green", "red", "pink", "purple", "yellow", "orange", "cream", "other", "unknown"
+        "black",
+        "white",
+        "gray",
+        "navy",
+        "blue",
+        "skyblue",
+        "beige",
+        "brown",
+        "khaki",
+        "green",
+        "red",
+        "pink",
+        "purple",
+        "yellow",
+        "orange",
+        "cream",
+        "charcoal",
+        "ivory",
+        "camel",
+        "olive",
+        "wine",
+        "mint",
+        "silver",
+        "gold",
+        "lavender",
+        "mustard",
+        "denim",
+        "indigo",
+        "other",
+        "unknown",
     ],
-    "tone": ["dark", "mid", "light", "pastel", "vivid", "unknown"],
-    "pattern": ["solid", "stripe", "check", "dot", "graphic", "floral", "other", "unknown"],
-    "material": ["cotton", "denim", "knit", "wool", "leather", "poly", "linen", "other", "unknown"],
-    "fit": ["slim", "regular", "oversized", "wide", "unknown"],
-    "neckline": ["crew", "vneck", "collar", "turtleneck", "hood", "unknown"],
-    "sleeve": ["sleeveless", "short", "long", "unknown"],
-    "length": ["cropped", "waist", "hip", "long", "unknown"],
-    "closure": ["zipper", "button", "open", "none", "unknown"],
-    "style_tags": ["minimal", "classic", "street", "sporty", "feminine", "vintage", "business", "formal", "casual", "other"],
-    "season": ["spring", "summer", "fall", "winter"],
+    "tone": [
+        "light",
+        "dark",
+        "muted",
+        "vivid",
+        "pastel",
+        "deep",
+        "neon",
+        "neutral",
+        "other",
+        "unknown",
+    ],
+    "pattern": [
+        "solid",
+        "stripe",
+        "check",
+        "houndstooth",
+        "dot",
+        "floral",
+        "animal",
+        "argyle",
+        "graphic",
+        "camo",
+        "other",
+        "unknown",
+    ],
+    "material": [
+        "cotton",
+        "denim",
+        "knit",
+        "wool",
+        "leather",
+        "suede",
+        "poly",
+        "linen",
+        "silk",
+        "corduroy",
+        "fleece",
+        "velvet",
+        "chiffon",
+        "other",
+        "unknown",
+    ],
+    "fit": [
+        "tight",
+        "slim",
+        "regular",
+        "loose",
+        "oversized",
+        "a-line",
+        "flare",
+        "wide",
+        "other",
+        "unknown",
+    ],
+    "neckline": [
+        "crew",
+        "vneck",
+        "u-neck",
+        "collar",
+        "turtleneck",
+        "mock-neck",
+        "square",
+        "off-shoulder",
+        "boat-neck",
+        "hood",
+        "other",
+        "unknown",
+    ],
+    "sleeve": ["sleeveless", "cap", "short", "half", "long", "other", "unknown"],
+    "length": [
+        "cropped",
+        "waist",
+        "hip",
+        "thigh",
+        "knee",
+        "long",
+        "maxi",
+        "other",
+        "unknown",
+    ],
+    "closure": ["zipper", "button", "wrap", "hook", "open", "none", "other", "unknown"],
+    "style_tags": [
+        "minimal",
+        "classic",
+        "street",
+        "sporty",
+        "gorpcore",
+        "preppy",
+        "amekaji",
+        "feminine",
+        "chic",
+        "vintage",
+        "business",
+        "formal",
+        "casual",
+        "other",
+    ],
+    "season": ["spring", "summer", "fall", "winter", "all-season", "transitional"],
 }
 
 ALIASES = {
-    "category_main": {"clothing": "top", "sweater": "top", "knitwear": "top"},
-    "color": {"dark blue": "navy", "navy blue": "navy", "light blue": "skyblue"},
-    "neckline": {"round": "crew", "crew neck": "crew", "crewneck": "crew"},
-    "closure": {"no closure": "none", "none": "none"},
-    "tone": {"navy": "dark"},
+    "category_main": {
+        "clothing": "top",
+        "top": "top",
+        "sweater": "top",
+        "knitwear": "top",
+        "blouses": "top",
+        "cardigan": "outer",
+        "jacket": "outer",
+        "coat": "outer",
+        "puffer": "outer",
+        "pants": "bottom",
+        "trousers": "bottom",
+        "jeans": "bottom",
+        "skirt": "bottom",
+        "dress": "onepiece",
+        "gown": "onepiece",
+        "sneakers": "shoes",
+        "boots": "shoes",
+        "heels": "shoes",
+        "handbag": "accessory",
+        "cap": "accessory",
+        "hat": "accessory",
+        "belt": "accessory",
+    },
+    "category_sub": {
+        "round-neck": "tshirt",
+        "tee": "tshirt",
+        "knitted-sweater": "knit",
+        "pullover": "sweater",
+        "slacks": "slacks",
+        "suit-pants": "slacks",
+        "chinos": "slacks",
+        "denim-pants": "jeans",
+        "blue-jeans": "jeans",
+        "mini-skirt": "skirt",
+        "maxi-skirt": "skirt",
+        "running-shoes": "sneakers",
+        "trainers": "sneakers",
+        "camisole": "camisoles",
+        "tank-top": "camisoles",
+        "beanie": "cap",
+        "beret": "hat",
+        "muffler": "scarf",
+    },
+    "color": {
+        "dark blue": "indigo",
+        "navy blue": "indigo",  # 진청/남색은 indigo로 통일
+        "light blue": "skyblue",
+        "baby blue": "skyblue",
+        "wine red": "wine",
+        "burgundy": "wine",
+        "dark green": "olive",
+        "forest green": "olive",
+        "gold metal": "gold",
+        "silver metal": "silver",
+        "off white": "ivory",
+        "bone": "ivory",
+    },
+    "tone": {
+        "navy": "dark",
+        "darkest": "dark",
+        "pale": "pastel",
+        "soft": "pastel",
+        "dusty": "muted",
+        "ashy": "muted",  # Muted 톤 매핑 추가
+        "bright": "vivid",
+        "electric": "neon",
+        "rich": "deep",
+        "strong": "deep",  # Deep 톤 매핑 추가
+    },
+    "neckline": {
+        "round": "crew",
+        "crew neck": "crew",
+        "crewneck": "crew",
+        "polo": "collar",
+        "shirt neck": "collar",
+        "half-turtleneck": "mock-neck",
+        "semi-turtleneck": "mock-neck",  # 모크넥 매핑
+        "low cut": "u-neck",
+        "scoop": "u-neck",
+    },
+    "material": {
+        "polyester": "poly",
+        "nylon": "poly",
+        "synthetic": "poly",
+        "jeans": "denim",
+        "jean": "denim",
+        "cashmere": "wool",
+        "angora": "wool",  # 울/모 계열 통합
+        "satin": "silk",
+        "shiny": "silk",
+    },
+    "fit": {
+        "baggy": "wide",
+        "relaxed": "loose",
+        "skinny": "tight",
+        "bodycon": "tight",
+        "comfy": "regular",
+        "standard": "regular",
+    },
+    "length": {
+        "short": "cropped",
+        "mini": "thigh",  # 기장 세분화 매핑
+        "midi": "knee",
+        "maxi": "long",
+        "full-length": "maxi",
+    },
+    "closure": {
+        "no closure": "none",
+        "invisible": "none",
+        "buttons": "button",
+        "zip": "zipper",
+        "tie": "wrap",
+        "ribbon": "wrap",  # 랩/끈 형태 매핑
+    },
 }
 
-REQUIRED_TOP_KEYS = {"category", "color", "pattern", "material", "fit", "details", "style_tags", "scores", "meta", "confidence"}
+# REQUIRED_TOP_KEYS
+REQUIRED_TOP_KEYS = {
+    "category",
+    "color",
+    "pattern",
+    "material",
+    "fit",
+    "neckline",
+    "sleeve",
+    "length",
+    "closure",
+    "style_tags",
+    "scores",
+    "meta",
+    "confidence",
+}
 
+# DEFAULT_OBJ
 DEFAULT_OBJ = {
     "category": {"main": "unknown", "sub": "unknown", "confidence": 0.2},
-    "color": {"primary": "unknown", "secondary": [], "tone": "unknown", "confidence": 0.2},
+    "color": {
+        "primary": "unknown",
+        "secondary": [],
+        "tone": "unknown",
+        "confidence": 0.2,
+    },
     "pattern": {"type": "unknown", "confidence": 0.2},
     "material": {"guess": "unknown", "confidence": 0.2},
     "fit": {"type": "unknown", "confidence": 0.2},
-    "details": {"neckline": "unknown", "sleeve": "unknown", "length": "unknown", "closure": ["unknown"], "print_or_logo": False},
+    "neckline": "unknown",
+    "sleeve": "unknown",
+    "length": "unknown",
+    "closure": ["none"],
     "style_tags": [],
-    "scores": {"formality": 0.3, "warmth": 0.3, "season": [], "versatility": 0.5},
-    "meta": {"is_layering_piece": False, "notes": None},
+    "scores": {
+        "formality": 0.3,
+        "warmth": 0.3,
+        "thickness": 0.3,
+        "season": [],
+        "versatility": 0.5,
+    },
+    "meta": {
+        "is_layering_piece": False,
+        "layering_rank": 2,
+        "print_or_logo": False,
+        "notes": None,
+    },
     "confidence": 0.2,
 }
 
@@ -59,11 +347,11 @@ SYSTEM_PROMPT = (
     "If uncertain, use 'unknown' or null and lower confidence."
 )
 
-# Azure OpenAI에 최적화된 사용자 프롬프트
-USER_PROMPT = f"""Extract attributes for the single clothing item in the image.
+# USER_PROMPT
+USER_PROMPT = f"""Extract attributes for the single clothing item in the image for a weather-based styling service.
 
 Return ONLY ONE JSON object with EXACTLY these top-level keys:
-category, color, pattern, material, fit, details, style_tags, scores, meta, confidence
+{', '.join(sorted(list(REQUIRED_TOP_KEYS)))}
 
 Schema (types):
 {{
@@ -72,50 +360,69 @@ Schema (types):
   "pattern": {{"type": string, "confidence": number}},
   "material": {{"guess": string, "confidence": number}},
   "fit": {{"type": string, "confidence": number}},
-  "details": {{
-    "neckline": string,
-    "sleeve": string,
-    "length": string,
-    "closure": [string],
-    "print_or_logo": boolean
-  }},
+  "neckline": string,
+  "sleeve": string,
+  "length": string,
+  "closure": [string],
   "style_tags": [string],
   "scores": {{
     "formality": number,
     "warmth": number,
+    "thickness": number,  // 0.1(Thin) ~ 1.0(Thick)
     "season": [string],
     "versatility": number
   }},
-  "meta": {{"is_layering_piece": boolean, "notes": string|null}},
+  "meta": {{
+    "is_layering_piece": boolean, 
+    "layering_rank": number, // 1: Inner, 2: Mid, 3: Outer
+    "print_or_logo": boolean,
+    "notes": string|null
+  }},
   "confidence": number
 }}
 
 Critical rules:
-- JSON only. No markdown. No commentary. No trailing text. No code blocks.
-- details.closure MUST be an ARRAY, e.g. ["none"] (never a string).
-- scores.season MUST be an ARRAY, e.g. ["winter"] (never a string).
-- confidence fields must be 0.0~1.0
-- Use lowercase tokens (short). If unsure use "unknown".
+- JSON only. No markdown. No commentary. No code blocks.
+- 'neckline', 'sleeve', 'length', and 'closure' MUST be top-level keys.
+- 'closure' and 'scores.season' MUST be an ARRAY of strings.
 - category.main must be one of {ENUMS["category_main"]}.
 - color.tone must be one of {ENUMS["tone"]}.
+- material.guess must be one of {ENUMS["material"]}.
+- Use lowercase tokens. Use "unknown" if unsure.
 """
 
+
+# build_retry_prompt
 def build_retry_prompt(errors: List[str]) -> str:
-    """재시도용 프롬프트 생성"""
+    """재시도용 프롬프트 생성: 여태까지의 첨삭 사항 및 스키마 변경 반영"""
+
+    # AI가 반드시 지켜야 할 Top-level 키 리스트 (알파벳 순 정렬)
+    expected_keys = sorted(list(REQUIRED_TOP_KEYS))
+
     return f"""Fix your output to be VALID JSON and match the schema EXACTLY.
 
-Errors:
+Errors detected in your previous response:
 - {chr(10).join(errors[:10])}
 
-MUST:
-- Return ONLY ONE JSON object. No extra text, no markdown, no code blocks.
-- Top-level keys must be EXACTLY: {sorted(list(REQUIRED_TOP_KEYS))}
-- details.closure MUST be an ARRAY of strings (e.g. ["none"]).
-- scores.season MUST be an ARRAY of strings (e.g. ["winter"]).
-- All confidences must be 0.0~1.0.
-- category.main must be one of {ENUMS["category_main"]}.
-- color.tone must be one of {ENUMS["tone"]}.
-- Use "unknown" if unsure.
+MUST FOLLOW THESE CRITICAL RULES:
+1. Return ONLY ONE JSON object. No extra text, no markdown (no ```json), no code blocks.
+2. Top-level keys must be EXACTLY: {expected_keys}
+3. 'neckline', 'sleeve', and 'length' MUST be top-level keys (NOT nested under details).
+4. 'closure' and 'scores.season' MUST be an ARRAY of strings (e.g., ["button"], ["spring", "fall"]).
+5. All confidence and score fields must be between 0.0 and 1.0.
+6. 'meta.layering_rank' must be an integer (1, 2, or 3).
 
+STRICT ENUM VALIDATION:
+- category.main: {ENUMS["category_main"]}
+- color.tone: {ENUMS["tone"]}
+- material.guess: {ENUMS["material"]}
+- fit.type: {ENUMS["fit"]}
+- pattern.type: {ENUMS["pattern"]}
+- neckline: {ENUMS["neckline"]}
+- sleeve: {ENUMS["sleeve"]}
+- length: {ENUMS["length"]}
+- season: {ENUMS["season"]}
+
+Use "unknown" for any field if you are unsure or the attribute is not visible.
 Return corrected JSON ONLY.
 """

--- a/app/ai/prompts/recommendation_prompts.py
+++ b/app/ai/prompts/recommendation_prompts.py
@@ -1,6 +1,7 @@
 """
 코디 추천 프롬프트 템플릿
 """
+
 import json
 from typing import List, Dict, Any
 
@@ -8,19 +9,9 @@ from typing import List, Dict, Any
 def build_recommendation_prompt(
     tops_summary: List[Dict[str, Any]],
     bottoms_summary: List[Dict[str, Any]],
-    count: int = 1
+    count: int = 1,
 ) -> str:
-    """
-    코디 추천 프롬프트 생성
-    
-    Args:
-        tops_summary: 상의 요약 정보 리스트
-        bottoms_summary: 하의 요약 정보 리스트
-        count: 추천할 코디 개수
-    
-    Returns:
-        프롬프트 문자열
-    """
+    """기본 상/하의 조합 추천 (단순 버전)"""
     return f"""Recommend {count} best outfit(s) from these pre-filtered combinations.
 
 Tops: {json.dumps(tops_summary, ensure_ascii=False)}
@@ -43,53 +34,57 @@ JSON only, no markdown, no code blocks."""
 def build_tpo_recommendation_prompt(
     user_request: str,
     weather_info: Dict[str, Any],
-    tops_summary: List[Dict[str, Any]],
-    bottoms_summary: List[Dict[str, Any]],
-    count: int = 1
+    tops_summary: List[Dict[str, Any]],  # 원본 인자 유지
+    bottoms_summary: List[Dict[str, Any]],  # 원본 인자 유지
+    outer_summary: List[Dict[str, Any]] = None,  # 아우터 추가 (선택사항)
+    count: int = 1,
 ) -> str:
     """
-    TPO(Time, Place, Occasion)를 고려한 코디 추천 프롬프트 생성
-    
-    Args:
-        user_request: 사용자 요청 (예: "격식 있는 저녁 식사")
-        weather_info: 날씨 정보
-        tops_summary: 상의 요약 정보 리스트
-        bottoms_summary: 하의 요약 정보 리스트
-        count: 추천할 코디 개수
-    
-    Returns:
-        프롬프트 문자열
+    원본의 인자 구조를 유지하면서 상세 속성(소재, 레이어링 등) 로직을 결합한 버전
     """
+
+    # 데이터를 AI가 읽기 좋게 카테고리별로 묶어줌
+    wardrobe_context = {
+        "top": tops_summary,
+        "bottom": bottoms_summary,
+        "outer": outer_summary if outer_summary else [],
+    }
+
     weather_text = ""
     if weather_info:
         weather_text = f"""
-Weather Information:
-- Temperature: {weather_info.get('temperature', 'N/A')}°C
+Current Weather:
+- Temp: {weather_info.get('temperature', 'N/A')}°C
 - Condition: {weather_info.get('condition', 'N/A')}
 - Precipitation: {weather_info.get('precipitation', 'N/A')}
 """
-    
-    return f"""Recommend {count} best outfit(s) based on the user's request and current weather.
 
+    return f"""Recommend {count} outfit(s) based on the context.
+
+[Context]
 User Request: {user_request}
 {weather_text}
-Available Tops: {json.dumps(tops_summary, ensure_ascii=False)}
-Available Bottoms: {json.dumps(bottoms_summary, ensure_ascii=False)}
 
-Consider:
-- User's request (TPO: Time, Place, Occasion)
-- Weather appropriateness
-- Color harmony
-- Style match
-- Formality balance
+[Available Items]
+{json.dumps(wardrobe_context, ensure_ascii=False)}
 
-Return JSON array with {count} object(s):
+[Styling Rules]
+1. Weather: Combine 'scores.warmth' and 'thickness' to match the Temp. 
+2. Safety: If precipitation is not "none", avoid "suede", "silk", "leather".
+3. Layering: Follow 'meta.layering_rank' (1:Inner, 2:Mid, 3:Outer).
+4. Category: Must include (1 Top + 1 Bottom). Add 1 Outer if Temp < 15°C.
+
+Return ONLY a JSON array of {count} objects:
 {{
-  "top_id": "string",
-  "bottom_id": "string",
+  "outfit_id": "outfit_n",
+  "combination": {{
+    "outer_id": "string|null",
+    "top_id": "string",
+    "bottom_id": "string"
+  }},
   "score": 0.0-1.0,
-  "reasoning": "한국어 100자 이내 - 날씨와 TPO를 고려한 추천 이유",
+  "reasoning": "한국어 100자 이내 (날씨/TPO/소재 고려)",
   "style_description": "한국어 50자 이내"
 }}
 
-JSON only, no markdown, no code blocks."""
+JSON only, no markdown."""


### PR DESCRIPTION
프롬프트 수정. 테스트 필요
extraction_prompts
[category_main]
bag 제거, bag -> accessory의 하위분류

[category_sub]
blouses, camisoles 추가

[color]
"charcoal", "ivory", "camel", "olive", "wine", "mint", "silver", "gold", "lavender", "mustard" 추가

[tone]
vivid, pastel, muted, deep

[pattern]
Houndstooth, Animal, Argyle, Camo

[material]
Corduroy, Velvet, Silk, Suede, Fleece, Chiffon

[pattern]
Houndstooth, Animal, Argyle, Camo

[fit]
A-line, Tight, Loose, Flare

[neckline]
Mock-neck, Square, Off-shoulder, U-neck, Boat-neck

[Sleeve]
Half, Cap

[Length]
Thigh, Knee, Maxi

[Closure]
Wrap, Hook

[Style Tags]
Preppy, Amekaji, Gorpcore, Chic

[Season]
All-season, Transitional

등
recommendation_prompts
tops_summary, bottoms_summary 인자 유지

outer_summary None으로 선택적 인자

Precipitation 비 눈 등 기상악화시 특정 소재를 피하게 로직

wardrobe_context 딕셔너리로 데이터를 한 번 묶어서 전달 -> LLM 정확성 증가